### PR TITLE
feat: :sparkles: Add ticket-summary command for generating custom per…

### DIFF
--- a/src/commands/guild/__tests__/ticket-summary.test.ts
+++ b/src/commands/guild/__tests__/ticket-summary.test.ts
@@ -1,0 +1,542 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { container } from "@sapphire/pieces"
+import { ChannelType } from "discord.js"
+import { ViolationSummaryService } from "../../../services/violation-summary"
+import { TicketSummaryCommand } from "../ticket-summary"
+
+// Mock dependencies
+jest.mock("@sapphire/framework", () => ({
+  Command: class Command {
+    constructor() {
+      /* empty */
+    }
+    container = {
+      client: {},
+    }
+  },
+}))
+
+jest.mock("@sapphire/pieces", () => ({
+  container: {
+    playerClient: {
+      getPlayer: jest.fn(),
+    },
+    cachedComlinkClient: {
+      getPlayer: jest.fn(),
+    },
+    ticketChannelClient: {
+      getGuildMessageChannels: jest.fn(),
+    },
+  },
+}))
+
+jest.mock("../../../services/violation-summary", () => ({
+  ViolationSummaryService: jest.fn().mockImplementation(() => ({
+    generateCustomPeriodSummary: jest.fn(),
+  })),
+}))
+
+jest.mock("../../../discord-bot-client", () => ({
+  DiscordBotClient: jest.fn(),
+}))
+
+const mockedContainer = jest.mocked(container)
+const MockedViolationSummaryService = jest.mocked(ViolationSummaryService)
+
+describe("TicketSummaryCommand", () => {
+  let command: TicketSummaryCommand
+  let mockInteraction: any
+  let mockChannel: any
+
+  beforeEach(() => {
+    // Create command instance
+    command = new TicketSummaryCommand({} as any, {} as any)
+
+    // Mock channel
+    mockChannel = {
+      id: "channel123",
+      type: ChannelType.GuildText,
+    }
+
+    // Mock interaction
+    mockInteraction = {
+      options: {
+        getInteger: jest.fn(),
+      },
+      channel: mockChannel,
+      user: {
+        id: "user123",
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      deferred: false,
+    }
+
+    // Reset mocks
+    jest.clearAllMocks()
+  })
+
+  describe("registerApplicationCommands", () => {
+    it("should register the ticket-summary command with correct options", () => {
+      const mockRegistry = {
+        registerChatInputCommand: jest.fn(),
+      }
+
+      command.registerApplicationCommands(mockRegistry as any)
+
+      expect(mockRegistry.registerChatInputCommand).toHaveBeenCalledTimes(1)
+      const [builderFn, options] =
+        mockRegistry.registerChatInputCommand.mock.calls[0]
+
+      // Test the builder function
+      const mockBuilder = {
+        setName: jest.fn().mockReturnThis(),
+        setDescription: jest.fn().mockReturnThis(),
+        addIntegerOption: jest.fn().mockReturnThis(),
+      }
+
+      const mockOption = {
+        setName: jest.fn().mockReturnThis(),
+        setDescription: jest.fn().mockReturnThis(),
+        setRequired: jest.fn().mockReturnThis(),
+        setMinValue: jest.fn().mockReturnThis(),
+        setMaxValue: jest.fn().mockReturnThis(),
+      }
+
+      mockBuilder.addIntegerOption.mockImplementation((optionFn) => {
+        optionFn(mockOption)
+        return mockBuilder
+      })
+
+      builderFn(mockBuilder)
+
+      expect(mockBuilder.setName).toHaveBeenCalledWith("ticket-summary")
+      expect(mockBuilder.setDescription).toHaveBeenCalledWith(
+        "Generate a custom period ticket summary",
+      )
+      expect(mockOption.setName).toHaveBeenCalledWith("days")
+      expect(mockOption.setDescription).toHaveBeenCalledWith(
+        "Number of days to include in the summary (1-90)",
+      )
+      expect(mockOption.setRequired).toHaveBeenCalledWith(true)
+      expect(mockOption.setMinValue).toHaveBeenCalledWith(1)
+      expect(mockOption.setMaxValue).toHaveBeenCalledWith(90)
+      expect(options.idHints).toEqual(["1376565769248444477"])
+    })
+  })
+
+  describe("chatInputRun", () => {
+    it("should return error for invalid days parameter", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(null)
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: "Please provide a valid number of days (1-90).",
+        ephemeral: true,
+      })
+    })
+
+    it("should return error for days less than 1", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(0)
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: "Please provide a valid number of days (1-90).",
+        ephemeral: true,
+      })
+    })
+
+    it("should return error for days greater than 90", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(91)
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: "Please provide a valid number of days (1-90).",
+        ephemeral: true,
+      })
+    })
+
+    it("should return error for invalid channel type", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(30)
+      mockInteraction.channel = null
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: "This command can only be used in a text channel or DM.",
+        ephemeral: true,
+      })
+    })
+
+    it("should return error for unsupported channel type", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(30)
+      mockInteraction.channel = {
+        type: ChannelType.GuildVoice,
+      }
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: "This command can only be used in a text channel or DM.",
+        ephemeral: true,
+      })
+    })
+
+    it("should handle successful ticket summary generation", async () => {
+      // Setup valid parameters
+      mockInteraction.options.getInteger.mockReturnValue(30)
+
+      // Mock successful guild registration
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({
+        allyCode: "123456789",
+      } as any)
+      mockedContainer.cachedComlinkClient.getPlayer.mockResolvedValue({
+        guildId: "guild123",
+        guildName: "Test Guild",
+      } as any)
+      mockedContainer.ticketChannelClient.getGuildMessageChannels.mockResolvedValue(
+        {
+          ticket_collection_channel_id: "channel456",
+        } as any,
+      )
+
+      // Mock ViolationSummaryService
+      const mockSummaryService = {
+        generateCustomPeriodSummary: jest.fn().mockResolvedValue(undefined),
+      }
+      MockedViolationSummaryService.mockImplementation(
+        () => mockSummaryService as any,
+      )
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.deferReply).toHaveBeenCalled()
+      expect(
+        mockSummaryService.generateCustomPeriodSummary,
+      ).toHaveBeenCalledWith("guild123", "channel123", "Test Guild", 30)
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content: "Ticket summary for the last 30 days has been posted.",
+      })
+    })
+
+    it("should handle error when player not registered", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(30)
+      mockedContainer.playerClient.getPlayer.mockResolvedValue(null)
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.deferReply).toHaveBeenCalled()
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content:
+          "You don't have a registered ally code. Please register with `/register-player` first.",
+      })
+    })
+
+    it("should handle error when player has no ally code", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(30)
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({} as any)
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.deferReply).toHaveBeenCalled()
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content:
+          "You don't have a registered ally code. Please register with `/register-player` first.",
+      })
+    })
+
+    it("should handle error when guild data not found", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(30)
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({
+        allyCode: "123456789",
+      } as any)
+      mockedContainer.cachedComlinkClient.getPlayer.mockResolvedValue(null)
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.deferReply).toHaveBeenCalled()
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content: "Could not find your Star Wars guild data.",
+      })
+    })
+
+    it("should handle error when guild not registered for tickets", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(30)
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({
+        allyCode: "123456789",
+      } as any)
+      mockedContainer.cachedComlinkClient.getPlayer.mockResolvedValue({
+        guildId: "guild123",
+        guildName: "Test Guild",
+      } as any)
+      mockedContainer.ticketChannelClient.getGuildMessageChannels.mockResolvedValue(
+        null,
+      )
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.deferReply).toHaveBeenCalled()
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content:
+          "Your Star Wars guild is not registered for ticket collection. Use `/register-ticket-collection` first.",
+      })
+    })
+
+    it("should handle error when guild has no ticket collection channel", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(30)
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({
+        allyCode: "123456789",
+      } as any)
+      mockedContainer.cachedComlinkClient.getPlayer.mockResolvedValue({
+        guildId: "guild123",
+        guildName: "Test Guild",
+      } as any)
+      mockedContainer.ticketChannelClient.getGuildMessageChannels.mockResolvedValue(
+        {} as any,
+      )
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.deferReply).toHaveBeenCalled()
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content:
+          "Your Star Wars guild is not registered for ticket collection. Use `/register-ticket-collection` first.",
+      })
+    })
+
+    it("should handle unexpected errors before defer", async () => {
+      mockInteraction.options.getInteger.mockImplementation(() => {
+        throw new Error("Unexpected error")
+      })
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content:
+          "An error occurred while generating the ticket summary. Please try again later.",
+        ephemeral: true,
+      })
+    })
+
+    it("should handle unexpected errors after defer", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(30)
+      mockInteraction.deferred = true
+      mockedContainer.playerClient.getPlayer.mockRejectedValue(
+        new Error("Database error"),
+      )
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(mockInteraction.deferReply).toHaveBeenCalled()
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content:
+          "An error occurred while generating the ticket summary. Please try again later.",
+      })
+    })
+
+    it("should work with DM channel", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(7)
+      mockInteraction.channel = {
+        id: "dm123",
+        type: ChannelType.DM,
+      }
+
+      // Mock successful flow
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({
+        allyCode: "123456789",
+      } as any)
+      mockedContainer.cachedComlinkClient.getPlayer.mockResolvedValue({
+        guildId: "guild123",
+        guildName: "Test Guild",
+      } as any)
+      mockedContainer.ticketChannelClient.getGuildMessageChannels.mockResolvedValue(
+        {
+          ticket_collection_channel_id: "channel456",
+        } as any,
+      )
+
+      const mockSummaryService = {
+        generateCustomPeriodSummary: jest.fn().mockResolvedValue(undefined),
+      }
+      MockedViolationSummaryService.mockImplementation(
+        () => mockSummaryService as any,
+      )
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(
+        mockSummaryService.generateCustomPeriodSummary,
+      ).toHaveBeenCalledWith("guild123", "dm123", "Test Guild", 7)
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content: "Ticket summary for the last 7 days has been posted.",
+      })
+    })
+
+    it("should work with GuildAnnouncement channel", async () => {
+      mockInteraction.options.getInteger.mockReturnValue(14)
+      mockInteraction.channel = {
+        id: "announcement123",
+        type: ChannelType.GuildAnnouncement,
+      }
+
+      // Mock successful flow
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({
+        allyCode: "123456789",
+      } as any)
+      mockedContainer.cachedComlinkClient.getPlayer.mockResolvedValue({
+        guildId: "guild123",
+        guildName: "Test Guild",
+      } as any)
+      mockedContainer.ticketChannelClient.getGuildMessageChannels.mockResolvedValue(
+        {
+          ticket_collection_channel_id: "channel456",
+        } as any,
+      )
+
+      const mockSummaryService = {
+        generateCustomPeriodSummary: jest.fn().mockResolvedValue(undefined),
+      }
+      MockedViolationSummaryService.mockImplementation(
+        () => mockSummaryService as any,
+      )
+
+      await command.chatInputRun(mockInteraction)
+
+      expect(
+        mockSummaryService.generateCustomPeriodSummary,
+      ).toHaveBeenCalledWith("guild123", "announcement123", "Test Guild", 14)
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content: "Ticket summary for the last 14 days has been posted.",
+      })
+    })
+  })
+
+  describe("getGuildRegistration", () => {
+    it("should return success with valid guild registration", async () => {
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({
+        allyCode: "123456789",
+        altAllyCodes: [],
+      })
+      mockedContainer.cachedComlinkClient.getPlayer.mockResolvedValue({
+        guildId: "guild123",
+        guildName: "Test Guild",
+        name: "Test Player",
+        allyCode: 123456789,
+        playerId: "player123",
+        level: 85,
+      })
+      mockedContainer.ticketChannelClient.getGuildMessageChannels.mockResolvedValue(
+        {
+          guild_id: "guild123",
+          ticket_collection_channel_id: "channel456",
+          next_ticket_collection_refresh_time: "2024-01-01T00:00:00Z",
+          anniversary_channel_id: undefined,
+        } as any,
+      )
+
+      const getGuildRegistration = (command as any).getGuildRegistration.bind(
+        command,
+      )
+      const result = await getGuildRegistration(mockInteraction)
+
+      expect(result).toEqual({
+        success: true,
+        response: { content: "" },
+        guildId: "guild123",
+        guildName: "Test Guild",
+      })
+    })
+
+    it("should return error for missing player", async () => {
+      mockedContainer.playerClient.getPlayer.mockResolvedValue(null)
+
+      const getGuildRegistration = (command as any).getGuildRegistration.bind(
+        command,
+      )
+      const result = await getGuildRegistration(mockInteraction)
+
+      expect(result).toEqual({
+        success: false,
+        response: {
+          content:
+            "You don't have a registered ally code. Please register with `/register-player` first.",
+        },
+      })
+    })
+
+    it("should return error for missing ally code", async () => {
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({} as any)
+
+      const getGuildRegistration = (command as any).getGuildRegistration.bind(
+        command,
+      )
+      const result = await getGuildRegistration(mockInteraction)
+
+      expect(result).toEqual({
+        success: false,
+        response: {
+          content:
+            "You don't have a registered ally code. Please register with `/register-player` first.",
+        },
+      })
+    })
+
+    it("should return error for missing guild data", async () => {
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({
+        allyCode: "123456789",
+        altAllyCodes: [],
+      } as any)
+      mockedContainer.cachedComlinkClient.getPlayer.mockResolvedValue({
+        guildId: undefined,
+        guildName: undefined,
+      } as any)
+
+      const getGuildRegistration = (command as any).getGuildRegistration.bind(
+        command,
+      )
+      const result = await getGuildRegistration(mockInteraction)
+
+      expect(result).toEqual({
+        success: false,
+        response: {
+          content: "Could not find your Star Wars guild data.",
+        },
+      })
+    })
+
+    it("should return error for unregistered guild", async () => {
+      mockedContainer.playerClient.getPlayer.mockResolvedValue({
+        allyCode: "123456789",
+        altAllyCodes: [],
+      } as any)
+      mockedContainer.cachedComlinkClient.getPlayer.mockResolvedValue({
+        guildId: "guild123",
+        guildName: "Test Guild",
+        name: "Test Player",
+        allyCode: 123456789,
+        playerId: "player123",
+        level: 85,
+      } as any)
+      mockedContainer.ticketChannelClient.getGuildMessageChannels.mockResolvedValue(
+        null,
+      )
+
+      const getGuildRegistration = (command as any).getGuildRegistration.bind(
+        command,
+      )
+      const result = await getGuildRegistration(mockInteraction)
+
+      expect(result).toEqual({
+        success: false,
+        response: {
+          content:
+            "Your Star Wars guild is not registered for ticket collection. Use `/register-ticket-collection` first.",
+        },
+      })
+    })
+  })
+})

--- a/src/commands/guild/ticket-summary.ts
+++ b/src/commands/guild/ticket-summary.ts
@@ -1,0 +1,159 @@
+import { Command } from "@sapphire/framework"
+import { container } from "@sapphire/pieces"
+import { ChannelType } from "discord.js"
+import { DiscordBotClient } from "../../discord-bot-client"
+import { ViolationSummaryService } from "../../services/violation-summary"
+
+export class TicketSummaryCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+    })
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName("ticket-summary")
+          .setDescription("Generate a custom period ticket summary")
+          .addIntegerOption((option) =>
+            option
+              .setName("days")
+              .setDescription("Number of days to include in the summary (1-90)")
+              .setRequired(true)
+              .setMinValue(1)
+              .setMaxValue(90),
+          ),
+      { idHints: ["1376565769248444477"] },
+    )
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    try {
+      // Get the days parameter
+      const days = interaction.options.getInteger("days")
+      if (!days || days < 1 || days > 90) {
+        return await interaction.reply({
+          content: "Please provide a valid number of days (1-90).",
+          ephemeral: true,
+        })
+      }
+
+      // Get the current channel
+      const channel = interaction.channel
+      if (
+        !channel ||
+        !(
+          channel.type === ChannelType.GuildText ||
+          channel.type === ChannelType.DM ||
+          channel.type === ChannelType.GuildAnnouncement
+        )
+      ) {
+        return await interaction.reply({
+          content: "This command can only be used in a text channel or DM.",
+          ephemeral: true,
+        })
+      }
+
+      // Defer the reply as this may take some time
+      await interaction.deferReply()
+
+      // Get guild info from registered data
+      const guildRegistration = await this.getGuildRegistration(interaction)
+      if (!guildRegistration.success) {
+        return await interaction.editReply(guildRegistration.response)
+      }
+
+      // Generate the summary
+      const client = this.container.client as unknown as DiscordBotClient
+      const summaryService = new ViolationSummaryService(client)
+
+      await summaryService.generateCustomPeriodSummary(
+        guildRegistration.guildId!,
+        channel.id,
+        guildRegistration.guildName!,
+        days,
+      )
+
+      return await interaction.editReply({
+        content: `Ticket summary for the last ${days} days has been posted.`,
+      })
+    } catch (error) {
+      console.error("Error in ticket-summary command:", error)
+
+      // If we haven't deferred yet, use reply instead of editReply
+      if (!interaction.deferred) {
+        return await interaction.reply({
+          content:
+            "An error occurred while generating the ticket summary. Please try again later.",
+          ephemeral: true,
+        })
+      }
+
+      return await interaction.editReply({
+        content:
+          "An error occurred while generating the ticket summary. Please try again later.",
+      })
+    }
+  }
+
+  private async getGuildRegistration(
+    interaction: Command.ChatInputCommandInteraction,
+  ): Promise<{
+    success: boolean
+    response: { content: string }
+    guildId?: string
+    guildName?: string
+  }> {
+    // Get the player's ally code
+    const player = await container.playerClient.getPlayer(interaction.user.id)
+    if (!player?.allyCode) {
+      return {
+        success: false,
+        response: {
+          content:
+            "You don't have a registered ally code. Please register with `/register-player` first.",
+        },
+      }
+    }
+
+    // Get the player's guild data
+    const playerData = await container.cachedComlinkClient.getPlayer(
+      player.allyCode,
+    )
+    if (!playerData?.guildId || !playerData?.guildName) {
+      return {
+        success: false,
+        response: {
+          content: "Could not find your Star Wars guild data.",
+        },
+      }
+    }
+
+    // Check if the player's SW guild is registered for ticket collection
+    const guildSettings =
+      await container.ticketChannelClient.getGuildMessageChannels(
+        playerData.guildId,
+      )
+
+    if (!guildSettings?.ticket_collection_channel_id) {
+      return {
+        success: false,
+        response: {
+          content:
+            "Your Star Wars guild is not registered for ticket collection. Use `/register-ticket-collection` first.",
+        },
+      }
+    }
+
+    return {
+      success: true,
+      response: { content: "" },
+      guildId: playerData.guildId,
+      guildName: playerData.guildName,
+    }
+  }
+}

--- a/src/db/guild-message-channels-client.ts
+++ b/src/db/guild-message-channels-client.ts
@@ -40,7 +40,7 @@ const QUERIES = {
   `,
 } as const
 
-export class TicketChannelPGClient {
+export class GuildMessageChannelsClient {
   private pool: Pool
 
   constructor() {

--- a/src/db/postgres-client.ts
+++ b/src/db/postgres-client.ts
@@ -1,19 +1,19 @@
 import { container } from "@sapphire/pieces"
+import { GuildMessageChannelsClient } from "./guild-message-channels-client"
 import { PlayerPGClient } from "./player-client"
-import { TicketChannelPGClient } from "./ticket-channel-client"
 import { TicketViolationPGClient } from "./ticket-violation-client"
 
 declare module "@sapphire/pieces" {
   interface Container {
     playerClient: PlayerPGClient
-    ticketChannelClient: TicketChannelPGClient
+    ticketChannelClient: GuildMessageChannelsClient
     ticketViolationClient: TicketViolationPGClient
   }
 }
 
 export const setupPostgresClients = (): void => {
   const playerClient = new PlayerPGClient()
-  const ticketChannelClient = new TicketChannelPGClient()
+  const ticketChannelClient = new GuildMessageChannelsClient()
   const ticketViolationClient = new TicketViolationPGClient()
 
   container.playerClient = playerClient


### PR DESCRIPTION
…iod summaries

- Implemented the /ticket-summary command to allow users to generate a summary of ticket violations over a specified number of days (1-90).
- Added validation for input parameters and error handling for various scenarios.
- Created associated tests to ensure command functionality and robustness.
- Introduced a new GuildMessageChannelsClient for managing guild message channels in the database.